### PR TITLE
Update to use PHP's ext-mongodb rather than the old ext-mongo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^7.1",
-        "doctrine/mongodb": "^1.0",
+        "mongodb/mongodb": ">=1.3",
         "symfony/console": "^2.7|^3.3|^4",
         "symfony/yaml": "^2.7|^3.3|^4"
     },

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185742.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185742.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 class Version20140822185742 extends AbstractMigration
 {
@@ -20,7 +20,7 @@ class Version20140822185742 extends AbstractMigration
         $testA = $db->selectCollection('test_a');
         $this->analyze($testA);
 
-        $testA->ensureIndex(['actor' => -1]);
+        $testA->createIndex(['actor' => -1]);
     }
 
     public function down(Database $db)
@@ -48,7 +48,7 @@ class Version20140822185742 extends AbstractMigration
             $testDocuments[] = $testDocument;
         }
 
-        $testA->batchInsert($testDocuments);
+        $testA->insertMany($testDocuments);
     }
 
     /**

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185743.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185743.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 class Version20140822185743 extends AbstractMigration
 {
@@ -21,7 +21,7 @@ class Version20140822185743 extends AbstractMigration
         $this->analyze($testA);
 
         // This will remove all records with actor property starting with character a-m
-        $result = $this->executeScript($db, 'test_script.js');
+        $this->executeScript($db, 'test_script.js');
     }
 
     public function down(Database $db)
@@ -49,7 +49,7 @@ class Version20140822185743 extends AbstractMigration
             $testDocuments[] = $testDocument;
         }
 
-        $testA->batchInsert($testDocuments);
+        $testA->insertMany($testDocuments);
     }
 
     /**

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185744.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185744.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
+++ b/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
@@ -14,8 +14,8 @@ namespace AntiMattr\MongoDB\Migrations;
 use AntiMattr\MongoDB\Migrations\Exception\AbortException;
 use AntiMattr\MongoDB\Migrations\Exception\IrreversibleException;
 use AntiMattr\MongoDB\Migrations\Exception\SkipException;
-use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Database;
+use MongoDB\Collection;
+use MongoDB\Database;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -56,7 +56,7 @@ abstract class AbstractMigration
     abstract public function down(Database $db);
 
     /**
-     * @param \Doctrine\MongoDB\Collection
+     * @param \MongoDB\Collection
      */
     protected function analyze(Collection $collection)
     {
@@ -64,8 +64,12 @@ abstract class AbstractMigration
     }
 
     /**
-     * @param \Doctrine\MongoDB\Database
-     * @param string $filename
+     * @param Database $db
+     * @param string   $filename
+     *
+     * @return array
+     *
+     * @throws \Exception
      */
     protected function executeScript(Database $db, $filename)
     {

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/ConfigurationBuilder.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/ConfigurationBuilder.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace AntiMattr\MongoDB\Migrations\Configuration;
 
 use AntiMattr\MongoDB\Migrations\OutputWriter;
-use Doctrine\MongoDB\Connection;
+use MongoDB\Client;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -23,7 +23,7 @@ use Symfony\Component\Yaml\Yaml;
 class ConfigurationBuilder
 {
     /**
-     * @var \Doctrine\MongoDB\Connection
+     * @var Client
      */
     private $connection;
 
@@ -64,11 +64,11 @@ class ConfigurationBuilder
     }
 
     /**
-     * @param Connection $connection
+     * @param Client $connection
      *
      * @return ConfigurationBuilder
      */
-    public function setConnection(Connection $connection): ConfigurationBuilder
+    public function setConnection(Client $connection): ConfigurationBuilder
     {
         $this->connection = $connection;
 

--- a/src/AntiMattr/MongoDB/Migrations/OutputWriter.php
+++ b/src/AntiMattr/MongoDB/Migrations/OutputWriter.php
@@ -21,7 +21,7 @@ class OutputWriter
     public function __construct(\Closure $closure = null)
     {
         if (null === $closure) {
-            $closure = function($message) {
+            $closure = function ($message) {
             };
         }
         $this->closure = $closure;

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -14,7 +14,7 @@ namespace AntiMattr\MongoDB\Migrations\Tools\Console\Command;
 use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
 use AntiMattr\MongoDB\Migrations\Configuration\ConfigurationBuilder;
 use AntiMattr\MongoDB\Migrations\OutputWriter;
-use Doctrine\MongoDB\Connection;
+use MongoDB\Client;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -79,7 +79,7 @@ abstract class AbstractCommand extends Command
         if (!$this->configuration) {
             $conn = $this->getDatabaseConnection($input);
 
-            $outputWriter = new OutputWriter(function($message) use ($output) {
+            $outputWriter = new OutputWriter(function ($message) use ($output) {
                 return $output->writeln($message);
             });
 
@@ -98,9 +98,11 @@ abstract class AbstractCommand extends Command
     /**
      * @param InputInterface $input
      *
-     * @return Connection
+     * @return Client
+     *
+     * @throws \MongoConnectionException
      */
-    protected function getDatabaseConnection(InputInterface $input): Connection
+    protected function getDatabaseConnection(InputInterface $input): Client
     {
         // Default to document manager helper set
         if ($this->getApplication()->getHelperSet()->has('dm')) {
@@ -136,7 +138,9 @@ abstract class AbstractCommand extends Command
     /**
      * @param array $params
      *
-     * @return \Doctrine\MongoDB\Connection
+     * @return Client
+     *
+     * @throws \MongoConnectionException
      */
     protected function createConnection($params)
     {
@@ -166,6 +170,6 @@ abstract class AbstractCommand extends Command
             $options = $params['options'];
         }
 
-        return new Connection($server, $options);
+        return new Client($server, $options);
     }
 }

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -11,7 +11,6 @@
 
 namespace AntiMattr\MongoDB\Migrations\Tools\Console\Command;
 
-use AntiMattr\MongoDB\Migrations\Migration;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -29,7 +29,7 @@ class GenerateCommand extends AbstractCommand
 namespace <namespace>;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -11,7 +11,6 @@
 
 namespace AntiMattr\MongoDB\Migrations\Tools\Console\Command;
 
-use AntiMattr\MongoDB\Migrations\Migration;
 use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationBuilderTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationBuilderTest.php
@@ -11,7 +11,7 @@ class ConfigurationBuilderTest extends TestCase
 {
     public function testBuildingConfiguration()
     {
-        $conn = $this->createMock('Doctrine\MongoDB\Connection');
+        $conn = $this->createMock('MongoDB\Client');
         $outputWriter = new OutputWriter();
         $onDiskConfig = '';
 
@@ -28,7 +28,7 @@ class ConfigurationBuilderTest extends TestCase
 
     public function testBuildingWithYamlConfig()
     {
-        $conn = $this->createMock('Doctrine\MongoDB\Connection');
+        $conn = $this->createMock('MongoDB\Client');
         $outputWriter = new OutputWriter();
         $onDiskConfig = dirname(__DIR__) . '/Resources/fixtures/config.yml';
 
@@ -52,7 +52,7 @@ class ConfigurationBuilderTest extends TestCase
 
     public function testBuildingWithXmlConfig()
     {
-        $conn = $this->createMock('Doctrine\MongoDB\Connection');
+        $conn = $this->createMock('MongoDB\Client');
         $outputWriter = new OutputWriter();
         $onDiskConfig = dirname(__DIR__) . '/Resources/fixtures/config.xml';
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/OutputWriterTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/OutputWriterTest.php
@@ -13,7 +13,7 @@ class OutputWriterTest extends TestCase
     {
         $this->output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
         $output = $this->output;
-        $this->outputWriter = new OutputWriter(function($message) use ($output) {
+        $this->outputWriter = new OutputWriter(function ($message) use ($output) {
             return $output->writeln($message);
         });
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185742.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185742.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185743.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185743.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185744.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185744.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -3,7 +3,6 @@
 namespace AntiMattr\Tests\MongoDB\Migrations\Tools\Console\Command;
 
 use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
-use AntiMattr\MongoDB\Migrations\Migration;
 use AntiMattr\MongoDB\Migrations\Tools\Console\Command\StatusCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -5,7 +5,7 @@ namespace AntiMattr\Tests\MongoDB\Migrations;
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
 use AntiMattr\MongoDB\Migrations\Version;
 use PHPUnit\Framework\TestCase;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 use MongoDB\BSON\UTCDateTime;
 
 class VersionTest extends TestCase
@@ -24,8 +24,8 @@ class VersionTest extends TestCase
     {
         $this->className = 'AntiMattr\Tests\MongoDB\Migrations\Version20140908000000';
         $this->configuration = $this->createMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
-        $this->connection = $this->createMock('Doctrine\MongoDB\Connection');
-        $this->db = $this->createMock('Doctrine\MongoDB\Database');
+        $this->connection = $this->createMock('MongoDB\Client');
+        $this->db = $this->createMock('MongoDB\Database');
         $this->migration = $this->createMock('AntiMattr\Tests\MongoDB\Migrations\Version20140908000000');
         $this->outputWriter = $this->createMock('AntiMattr\MongoDB\Migrations\OutputWriter');
         $this->statistics = $this->createMock('AntiMattr\MongoDB\Migrations\Collection\Statistics');
@@ -57,13 +57,13 @@ class VersionTest extends TestCase
 
     public function testAnalyzeThrowsException()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
 
         $collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('test_name'));
 
         $expectedException = new \RuntimeException();
@@ -80,13 +80,13 @@ class VersionTest extends TestCase
 
     public function testAnalyze()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
 
         $collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('test_name'));
 
         $this->statistics->expects($this->once())
@@ -103,7 +103,7 @@ class VersionTest extends TestCase
         $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -117,7 +117,7 @@ class VersionTest extends TestCase
         ];
 
         $collection->expects($this->once())
-            ->method('insert')
+            ->method('insertOne')
             ->with($insert);
 
         $this->version->markMigrated();
@@ -128,7 +128,7 @@ class VersionTest extends TestCase
         $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -146,7 +146,7 @@ class VersionTest extends TestCase
         ];
 
         $collection->expects($this->once())
-            ->method('update')
+            ->method('updateOne')
             ->with($query, $update);
 
         $replay = true;
@@ -158,7 +158,7 @@ class VersionTest extends TestCase
         $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -171,7 +171,7 @@ class VersionTest extends TestCase
         ];
 
         $collection->expects($this->once())
-            ->method('remove')
+            ->method('deleteOne')
             ->with($remove);
 
         $this->version->markNotMigrated();
@@ -179,7 +179,7 @@ class VersionTest extends TestCase
 
     public function testUpdateStatisticsAfterThrowsException()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
@@ -199,7 +199,7 @@ class VersionTest extends TestCase
 
     public function testUpdateStatisticsAfter()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
@@ -209,7 +209,7 @@ class VersionTest extends TestCase
             ->will($this->returnValue($collection));
 
         $collection->expects($this->exactly(2))
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('test_name'));
 
         $this->statistics->expects($this->once())
@@ -262,7 +262,7 @@ class VersionTest extends TestCase
             ->method($direction)
             ->will($this->throwException($expectedException));
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -287,7 +287,7 @@ class VersionTest extends TestCase
         $this->migration->expects($this->once())
             ->method('post' . $direction);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 


### PR DESCRIPTION
Initial conversion work to drop the usage of the Doctrine\MongoDB classes, and thus the old PHP 'mongo' extension.  This package now requires the new 'mongodb' extension and its corresponding PHP library.